### PR TITLE
fix: keep public feed resilient to auth failures

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
 import { getBookmarkedIds } from "@/app/actions/bookmarks";
 import { getHiddenState } from "@/app/actions/hidden";
 import { HomeContent } from "@/components/home-content";
+import type { HomeContentProps } from "@/components/home-content";
 import { Skeleton } from "@/components/ui/skeleton";
 
 // ─── Route Segment Config ───────────────────────────────────────────
@@ -36,6 +37,14 @@ export const metadata: Metadata = {
 };
 
 // ─── Helpers ────────────────────────────────────────────────────────
+
+type HiddenState = NonNullable<HomeContentProps["hiddenState"]>;
+
+const EMPTY_HIDDEN_STATE: HiddenState = {
+  hiddenArticleIds: [],
+  hiddenSources: [],
+  hiddenTopics: [],
+};
 
 /**
  * Determine the default edition type based on the current hour in Asia/Tokyo.
@@ -109,8 +118,10 @@ export default async function HomePage() {
  * show a skeleton while the DB and Redis queries resolve.
  */
 /**
- * Fetch all edition data, returning null on any failure.
- * Separated from JSX to satisfy react-hooks/error-boundaries lint rule.
+ * Fetch all edition data while keeping public news independent from personalization.
+ * @returns Edition data when DB content exists, otherwise `null` for the no-edition state.
+ * @example
+ * const data = await fetchEditionData();
  */
 async function fetchEditionData() {
   try {
@@ -120,8 +131,8 @@ async function fetchEditionData() {
     const [edition, widgets, bookmarkedIds, hiddenState] = await Promise.all([
       getEdition(editionType, today).then((e) => e ?? getLatestEdition()),
       getWidgetData(),
-      getBookmarkedIds(),
-      getHiddenState(),
+      getSafeBookmarkedIds(),
+      getSafeHiddenState(),
     ]);
 
     if (!edition) return null;
@@ -129,6 +140,42 @@ async function fetchEditionData() {
     return { edition, widgets, bookmarkedIds, hiddenState };
   } catch {
     return null;
+  }
+}
+
+/**
+ * Read bookmark IDs without letting Auth.js configuration errors hide public editions.
+ * @returns Bookmark IDs for signed-in users, or an empty list when unavailable.
+ * @example
+ * const bookmarkedIds = await getSafeBookmarkedIds();
+ */
+async function getSafeBookmarkedIds(): Promise<string[]> {
+  try {
+    return await getBookmarkedIds();
+  } catch (error) {
+    console.error(
+      "[HomePage] Bookmark personalization unavailable; rendering public feed:",
+      error,
+    );
+    return [];
+  }
+}
+
+/**
+ * Read hidden filters without letting Auth.js configuration errors hide public editions.
+ * @returns Hidden filter state for signed-in users, or an empty state when unavailable.
+ * @example
+ * const hiddenState = await getSafeHiddenState();
+ */
+async function getSafeHiddenState(): Promise<HiddenState> {
+  try {
+    return await getHiddenState();
+  } catch (error) {
+    console.error(
+      "[HomePage] Hidden-item personalization unavailable; rendering public feed:",
+      error,
+    );
+    return EMPTY_HIDDEN_STATE;
   }
 }
 
@@ -162,10 +209,10 @@ function NoEditionFallback() {
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
       <div className="text-center">
-        <h2 className="text-2xl font-bold tracking-tight text-ms-text-primary">
+        <h2 className="text-ms-text-primary text-2xl font-bold tracking-tight">
           No edition available
         </h2>
-        <p className="mt-2 text-ms-text-secondary">
+        <p className="text-ms-text-secondary mt-2">
           The next edition is being prepared. Check back soon!
         </p>
       </div>

--- a/src/lib/queries/edition.ts
+++ b/src/lib/queries/edition.ts
@@ -151,56 +151,61 @@ export async function getWidgetData(): Promise<WidgetData> {
 // ─── Internal Helpers ────────────────────────────────────────────────
 
 /**
- * Filter articles based on the current user's hidden items.
- *
- * Queries the `hidden_items` table for the authenticated user and removes
- * articles matching hidden article IDs, hidden sources, or hidden topics
- * (case-insensitive title substring match).
- *
- * Returns the original list unchanged if no user is authenticated or
- * no hidden items exist.
+ * Filter articles for a signed-in user without making auth required for public feeds.
+ * @param allArticles - Articles loaded from the published edition.
+ * @returns Filtered articles for signed-in users, or the original list when auth/filtering is unavailable.
+ * @example
+ * const visibleArticles = await applyHiddenFilters(allArticles);
  */
 async function applyHiddenFilters(allArticles: Article[]): Promise<Article[]> {
-  const session = await auth();
-  if (!session?.user?.id) return allArticles;
+  try {
+    const session = await auth();
+    if (!session?.user?.id) return allArticles;
 
-  const hiddenRows = await db
-    .select({
-      targetType: hiddenItems.targetType,
-      targetId: hiddenItems.targetId,
-    })
-    .from(hiddenItems)
-    .where(eq(hiddenItems.userId, session.user.id));
+    const hiddenRows = await db
+      .select({
+        targetType: hiddenItems.targetType,
+        targetId: hiddenItems.targetId,
+      })
+      .from(hiddenItems)
+      .where(eq(hiddenItems.userId, session.user.id));
 
-  if (hiddenRows.length === 0) return allArticles;
+    if (hiddenRows.length === 0) return allArticles;
 
-  const hiddenArticleIds = new Set<string>();
-  const hiddenSources = new Set<string>();
-  const hiddenTopics: string[] = [];
+    const hiddenArticleIds = new Set<string>();
+    const hiddenSources = new Set<string>();
+    const hiddenTopics: string[] = [];
 
-  for (const row of hiddenRows) {
-    switch (row.targetType) {
-      case "article":
-        hiddenArticleIds.add(row.targetId);
-        break;
-      case "source":
-        hiddenSources.add(row.targetId);
-        break;
-      case "topic":
-        hiddenTopics.push(row.targetId.toLowerCase());
-        break;
-    }
-  }
-
-  return allArticles.filter((article) => {
-    if (hiddenArticleIds.has(article.externalId)) return false;
-    if (hiddenSources.has(article.source)) return false;
-    if (hiddenTopics.length > 0) {
-      const titleLower = article.title.toLowerCase();
-      for (const topic of hiddenTopics) {
-        if (titleLower.includes(topic)) return false;
+    for (const row of hiddenRows) {
+      switch (row.targetType) {
+        case "article":
+          hiddenArticleIds.add(row.targetId);
+          break;
+        case "source":
+          hiddenSources.add(row.targetId);
+          break;
+        case "topic":
+          hiddenTopics.push(row.targetId.toLowerCase());
+          break;
       }
     }
-    return true;
-  });
+
+    return allArticles.filter((article) => {
+      if (hiddenArticleIds.has(article.externalId)) return false;
+      if (hiddenSources.has(article.source)) return false;
+      if (hiddenTopics.length > 0) {
+        const titleLower = article.title.toLowerCase();
+        for (const topic of hiddenTopics) {
+          if (titleLower.includes(topic)) return false;
+        }
+      }
+      return true;
+    });
+  } catch (error) {
+    console.error(
+      "[Edition] Hidden filters unavailable; returning unfiltered public feed:",
+      error,
+    );
+    return allArticles;
+  }
 }


### PR DESCRIPTION
## Summary
- keep published editions visible even when Auth.js personalization fails
- return empty bookmark/hidden state when personalization is unavailable
- keep server-side hidden filtering from turning public feed loading into a no-edition fallback

## Verification
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint .
- ./node_modules/.bin/next build

## Note
Auth itself is intentionally left for the final auth-focused fix per project plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for personalization features to prevent service disruptions when authentication or data retrieval issues occur.
  * Public content now remains visible even if bookmarks or content filtering fail, ensuring better reliability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->