### PR TITLE
fix: prioritize mobile lead story over widgets

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -241,7 +241,7 @@ function HomePageSkeleton() {
             ))}
           </div>
         </div>
-        <div className="order-first flex flex-col gap-4 lg:order-last lg:flex-[1]">
+        <div className="flex flex-col gap-3 lg:flex-[1]">
           <Skeleton className="h-28 rounded-lg" />
           <Skeleton className="h-40 rounded-lg" />
         </div>

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -321,9 +321,9 @@ export function HomeContent({
           />
         </div>
 
-        {/* Widgets sidebar — 1/4 width on desktop, full-width on mobile above hero */}
+        {/* Widgets sidebar — secondary on mobile, right rail on desktop. */}
         <aside
-          className="order-first flex flex-col gap-4 lg:order-last lg:flex-[1]"
+          className="flex flex-col gap-3 lg:flex-[1]"
           aria-label="Daily widgets"
         >
           <WeatherWidget data={weather} />

--- a/src/components/widgets/stock-widget.tsx
+++ b/src/components/widgets/stock-widget.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { UnavailableWidgetState } from "@/components/widgets/unavailable-widget-state";
 import { cn } from "@/lib/utils";
 import type { StockData } from "@/lib/sources/stocks";
 
@@ -37,25 +38,22 @@ function formatChangePercent(pct: number): string {
 export function StockWidget({ data }: StockWidgetProps) {
   if (data.length === 0) {
     return (
-      <Card className="glass-panel rounded-md border-ms-glass-border">
-        <CardContent className="py-4">
-          <p className="text-center text-sm text-ms-text-muted">
-            Market data unavailable
-          </p>
-        </CardContent>
-      </Card>
+      <UnavailableWidgetState
+        title="Markets unavailable"
+        detail="No market snapshot for this edition."
+      />
     );
   }
 
   return (
-    <Card className="glass-panel rounded-md border-ms-glass-border">
-      <CardHeader className="pb-0 pt-3">
-        <CardTitle className="text-[10px] font-mono font-medium uppercase tracking-[0.2em] text-ms-text-muted">
+    <Card className="glass-panel border-ms-glass-border rounded-md">
+      <CardHeader className="pt-3 pb-0">
+        <CardTitle className="text-ms-text-muted font-mono text-[10px] font-medium uppercase">
           Markets
         </CardTitle>
       </CardHeader>
       <CardContent className="pb-3">
-        <ul className="divide-y divide-ms-border" role="list">
+        <ul className="divide-ms-border divide-y" role="list">
           {data.map((stock) => (
             <StockRow key={stock.symbol} stock={stock} />
           ))}
@@ -74,17 +72,17 @@ function StockRow({ stock }: { stock: StockData }) {
 
   return (
     <li className="flex items-center justify-between gap-2 py-2 first:pt-0 last:pb-0">
-      <span className="truncate text-sm font-medium text-ms-text-primary">
+      <span className="text-ms-text-primary truncate text-sm font-medium">
         {stock.name}
       </span>
 
       <div className="flex shrink-0 flex-col items-end">
-        <span className="font-mono text-sm tabular-nums text-ms-text-primary">
+        <span className="text-ms-text-primary font-mono text-sm tabular-nums">
           {formatPrice(stock.price, stock.currency)}
         </span>
         <span
           className={cn(
-            "font-mono text-xs tabular-nums font-medium",
+            "font-mono text-xs font-medium tabular-nums",
             isPositive && "text-ms-positive",
             isNegative && "text-ms-negative",
             !isPositive && !isNegative && "text-ms-text-muted",
@@ -104,7 +102,7 @@ function StockRow({ stock }: { stock: StockData }) {
 export function StockWidgetSkeleton() {
   return (
     <Card className="border-ms-border bg-ms-bg-secondary">
-      <CardHeader className="pb-0 pt-4">
+      <CardHeader className="pt-4 pb-0">
         <Skeleton className="h-3 w-16" />
       </CardHeader>
       <CardContent className="pb-4">

--- a/src/components/widgets/unavailable-widget-state.tsx
+++ b/src/components/widgets/unavailable-widget-state.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+export interface UnavailableWidgetStateProps {
+  /** Short unavailable state label shown as the row title. */
+  title: string;
+  /** Human-readable reason or expectation for the missing widget data. */
+  detail: string;
+}
+
+/**
+ * Renders compact widget status rows when edition-side data is missing.
+ * @param title - Short label for the unavailable widget data.
+ * @param detail - One-line reason shown below the label.
+ * @returns Compact card row that does not compete with the lead story.
+ * @example
+ * <UnavailableWidgetState title="Weather unavailable" detail="No weather snapshot for this edition." />
+ */
+export function UnavailableWidgetState({
+  title,
+  detail,
+}: UnavailableWidgetStateProps) {
+  return (
+    <Card className="glass-panel border-ms-glass-border rounded-md py-0">
+      <CardContent className="flex items-center gap-3 px-3 py-2.5">
+        <span
+          className="bg-ms-text-muted/50 size-1.5 shrink-0 rounded-full"
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <p className="text-ms-text-secondary text-xs font-medium">{title}</p>
+          <p className="text-ms-text-muted truncate text-[11px] leading-snug">
+            {detail}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/widgets/weather-widget.tsx
+++ b/src/components/widgets/weather-widget.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { UnavailableWidgetState } from "@/components/widgets/unavailable-widget-state";
 import type { WeatherData } from "@/lib/sources/weather";
 
 export interface WeatherWidgetProps {
@@ -20,70 +21,82 @@ export interface WeatherWidgetProps {
 export function WeatherWidget({ data }: WeatherWidgetProps) {
   if (!data) {
     return (
-      <Card className="glass-panel rounded-md border-ms-glass-border">
-        <CardContent className="py-4">
-          <p className="text-center text-sm text-ms-text-muted">
-            Weather data unavailable
-          </p>
-        </CardContent>
-      </Card>
+      <UnavailableWidgetState
+        title="Weather unavailable"
+        detail="No weather snapshot for this edition."
+      />
     );
   }
 
   return (
-    <Card className="glass-panel rounded-md border-ms-glass-border">
-      <CardHeader className="pb-0 pt-4">
-        <CardTitle className="text-[10px] font-mono font-medium uppercase tracking-[0.2em] text-ms-text-muted">
+    <Card className="glass-panel border-ms-glass-border rounded-md">
+      <CardHeader className="pt-4 pb-0">
+        <CardTitle className="text-ms-text-muted font-mono text-[10px] font-medium uppercase">
           Weather
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3 pb-4">
         {/* Current conditions */}
         <div className="flex items-center gap-3">
-          <span className="-ml-1 shrink-0 text-4xl" role="img" aria-label={data.condition}>
+          <span
+            className="-ml-1 shrink-0 text-4xl"
+            role="img"
+            aria-label={data.condition}
+          >
             {data.iconCode}
           </span>
 
           <div className="min-w-0">
             <div className="flex items-baseline gap-1">
-              <span className="font-mono text-3xl font-semibold tabular-nums text-ms-text-primary">
+              <span className="text-ms-text-primary font-mono text-3xl font-semibold tabular-nums">
                 {data.temperatureCelsius}°
               </span>
-              <span className="text-sm text-ms-text-muted">C</span>
+              <span className="text-ms-text-muted text-sm">C</span>
             </div>
-            <p className="truncate text-sm text-ms-text-secondary">
+            <p className="text-ms-text-secondary truncate text-sm">
               {data.condition}
             </p>
-            <p className="truncate text-xs text-ms-text-muted">{data.city}</p>
+            <p className="text-ms-text-muted truncate text-xs">{data.city}</p>
           </div>
         </div>
 
         {/* Humidity & Wind */}
-        <div className="flex gap-4 text-xs text-ms-text-muted">
+        <div className="text-ms-text-muted flex gap-4 text-xs">
           <span className="flex items-center gap-1">
-            <span role="img" aria-label="humidity">💧</span>
+            <span role="img" aria-label="humidity">
+              💧
+            </span>
             {data.humidity}%
           </span>
           <span className="flex items-center gap-1">
-            <span role="img" aria-label="wind">💨</span>
+            <span role="img" aria-label="wind">
+              💨
+            </span>
             {data.windSpeed} km/h
           </span>
         </div>
 
         {/* 3-day forecast */}
         {data.forecast.length > 0 && (
-          <div className="grid grid-cols-3 gap-2 border-t border-ms-glass-border pt-3">
+          <div className="border-ms-glass-border grid grid-cols-3 gap-2 border-t pt-3">
             {data.forecast.map((day) => {
               const label = formatDayLabel(day.date);
               return (
-                <div key={day.date} className="flex flex-col items-center gap-0.5">
-                  <span className="text-[10px] font-mono uppercase text-ms-text-muted">
+                <div
+                  key={day.date}
+                  className="flex flex-col items-center gap-0.5"
+                >
+                  <span className="text-ms-text-muted font-mono text-[10px] uppercase">
                     {label}
                   </span>
-                  <span className="text-lg" role="img" aria-label={day.condition}>
+                  <span
+                    className="text-lg"
+                    role="img"
+                    aria-label={day.condition}
+                  >
                     {day.icon}
                   </span>
-                  <div className="flex gap-1 text-[10px] font-mono tabular-nums">
+                  <div className="flex gap-1 font-mono text-[10px] tabular-nums">
                     <span className="text-ms-text-primary">{day.tempMax}°</span>
                     <span className="text-ms-text-muted">{day.tempMin}°</span>
                   </div>
@@ -115,8 +128,8 @@ function formatDayLabel(dateStr: string): string {
  */
 export function WeatherWidgetSkeleton() {
   return (
-    <Card className="glass-panel rounded-md border-ms-glass-border">
-      <CardHeader className="pb-0 pt-4">
+    <Card className="glass-panel border-ms-glass-border rounded-md">
+      <CardHeader className="pt-4 pb-0">
         <Skeleton className="h-3 w-16" />
       </CardHeader>
       <CardContent className="space-y-3 pb-4">
@@ -132,7 +145,7 @@ export function WeatherWidgetSkeleton() {
           <Skeleton className="h-3 w-12" />
           <Skeleton className="h-3 w-16" />
         </div>
-        <div className="grid grid-cols-3 gap-2 border-t border-ms-glass-border pt-3">
+        <div className="border-ms-glass-border grid grid-cols-3 gap-2 border-t pt-3">
           {[0, 1, 2].map((i) => (
             <div key={i} className="flex flex-col items-center gap-1">
               <Skeleton className="h-3 w-8" />


### PR DESCRIPTION
## Summary
- render the hero/feed before daily widgets on mobile
- replace large unavailable Weather/Markets cards with compact status rows
- reuse a shared widget unavailable state component

## Verification
- pnpm run typecheck && pnpm run lint && pnpm run build
- pnpm run test:e2e -- e2e/home.spec.ts

## Notes
- The production Auth.js session failure remains intentionally deferred to the final auth PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent “unavailable” widget UI for stock and weather widgets, including clear title/detail messaging.

* **Improvements**
  * Updated the widgets sidebar behavior to act as a secondary rail on mobile and a right rail on desktop.
  * Refined Suspense fallback skeleton layout in the main hero/widgets area.

* **Style**
  * Adjusted widget card, typography, and row styling for improved visual consistency, including loading skeleton presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->