### PR TITLE
fix: contain mobile section widths

### DIFF
--- a/src/components/sections/content-section.tsx
+++ b/src/components/sections/content-section.tsx
@@ -47,7 +47,10 @@ export function ContentSection({
   if (articles.length === 0) return null;
 
   return (
-    <section aria-label={title} className={cn("flex flex-col gap-3", className)}>
+    <section
+      aria-label={title}
+      className={cn("flex min-w-0 flex-col gap-3", className)}
+    >
       <SectionHeader icon={icon} title={title} viewAllHref={viewAllHref} />
 
       {/* Mobile: horizontal scroll  |  Tablet+: vertical stack */}

--- a/src/components/sections/github-prs-section.tsx
+++ b/src/components/sections/github-prs-section.tsx
@@ -297,7 +297,10 @@ export function GitHubPRsSection({
   if (articles.length === 0) return null;
 
   return (
-    <section aria-label="Pull Requests" className="flex flex-col gap-3">
+    <section
+      aria-label="Pull Requests"
+      className="flex min-w-0 flex-col gap-3"
+    >
       <SectionHeader icon="🔀" title="Pull Requests" />
 
       {/* Tab switcher */}

--- a/src/components/sections/hackernews-section.tsx
+++ b/src/components/sections/hackernews-section.tsx
@@ -301,7 +301,7 @@ export function HackerNewsSection({
   if (articles.length === 0) return null;
 
   return (
-    <section aria-label="Hacker News" className="flex flex-col gap-3">
+    <section aria-label="Hacker News" className="flex min-w-0 flex-col gap-3">
       <SectionHeader icon="🔶" title="Hacker News" />
 
       {/* Ranked list — no horizontal scroll needed for compact items */}

--- a/src/components/sections/sns-section.tsx
+++ b/src/components/sections/sns-section.tsx
@@ -428,11 +428,11 @@ export function SnsSection({
   if (!hasBluesky && !hasYoutube) return null;
 
   return (
-    <section aria-label="Social Media" className="flex flex-col gap-4">
+    <section aria-label="Social Media" className="flex min-w-0 flex-col gap-4">
       <div className="grid gap-4 sm:grid-cols-2">
         {/* Bluesky sub-section */}
         {hasBluesky && (
-          <div className="flex flex-col gap-4">
+          <div className="flex min-w-0 flex-col gap-4">
             <SectionHeader icon="🦋" title="Bluesky" />
             <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-none sm:flex-col sm:overflow-x-visible sm:pb-0">
               {blueskyArticles.slice(0, 3).map((article) => (
@@ -451,7 +451,7 @@ export function SnsSection({
 
         {/* YouTube sub-section */}
         {hasYoutube && (
-          <div className="flex flex-col gap-4">
+          <div className="flex min-w-0 flex-col gap-4">
             <SectionHeader icon="🎬" title="YouTube" />
             <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-none sm:flex-col sm:overflow-x-visible sm:pb-0">
               {youtubeArticles.slice(0, 3).map((article) => (


### PR DESCRIPTION
## Summary
- add min-width containment to content section roots used inside responsive grids
- keep mobile horizontal card scrollers from expanding the whole document width
- cover Hacker News, PR, and SNS section roots with the same containment

## Evidence
- production before fix: 390px viewport produced document scrollWidth 1406px with section roots widened to 1390px
- local after fix with edition data: innerWidth 390 / document scrollWidth 390
- local screenshot: docs/ux-gap-reports/screenshots/local-mobile-section-width-fix.png (untracked audit artifact)

## Tests
- pnpm run typecheck && pnpm run lint && pnpm run build
- kill-port 3198 && pnpm run test:e2e -- e2e/home.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout handling across multiple page sections to prevent content overflow and ensure proper flex container sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->