### PR TITLE
fix: handle unavailable auth providers

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -88,15 +88,30 @@ async function expectAccountAccessState(page: Page) {
     "Sign-in is temporarily unavailable",
   );
 
-  const hasGitHubButton = await githubButton.isVisible().catch(() => false);
-  const hasGoogleButton = await googleButton.isVisible().catch(() => false);
-  const hasUnavailableMessage = await unavailableMessage
-    .isVisible()
-    .catch(() => false);
+  await expect
+    .poll(
+      async () => {
+        const isGitHubButtonVisible = await githubButton
+          .isVisible()
+          .catch(() => false);
+        const isGoogleButtonVisible = await googleButton
+          .isVisible()
+          .catch(() => false);
+        const isUnavailableMessageVisible = await unavailableMessage
+          .isVisible()
+          .catch(() => false);
 
-  expect(
-    hasGitHubButton || hasGoogleButton || hasUnavailableMessage,
-  ).toBeTruthy();
+        return (
+          isGitHubButtonVisible ||
+          isGoogleButtonVisible ||
+          isUnavailableMessageVisible
+        );
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+
+  const hasUnavailableMessage = await unavailableMessage.isVisible();
 
   if (hasUnavailableMessage) {
     await expect(

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { waitForPageReady, isMobileViewport, openMobileMenu } from "./fixtures";
 
 test.describe("Navigation", () => {
@@ -12,10 +12,12 @@ test.describe("Navigation", () => {
     await expect(page).toHaveURL("/");
   });
 
-  test("login link navigates to login page", async ({ page }) => {
+  test("login link opens a usable account access page", async ({ page }) => {
+    // Arrange
     await page.goto("/");
     await waitForPageReady(page);
 
+    // Act
     if (isMobileViewport(page)) {
       await openMobileMenu(page);
       const mobileNav = page.getByLabel("Mobile navigation");
@@ -25,9 +27,9 @@ test.describe("Navigation", () => {
       await loginBtn.click();
     }
 
+    // Assert
     await expect(page).toHaveURL("/login");
-    await expect(page.getByText("Continue with GitHub")).toBeVisible();
-    await expect(page.getByText("Continue with Google")).toBeVisible();
+    await expectAccountAccessState(page);
   });
 
   test("about page loads correctly", async ({ page }) => {
@@ -38,14 +40,17 @@ test.describe("Navigation", () => {
     await expect(page.locator("main")).toBeVisible();
   });
 
-  test("login page shows OAuth providers", async ({ page }) => {
+  test("login page explains account access even before OAuth is configured", async ({
+    page,
+  }) => {
+    // Arrange / Act
     await page.goto("/login");
 
-    await expect(page.getByText("Continue with GitHub")).toBeVisible();
-    await expect(page.getByText("Continue with Google")).toBeVisible();
+    // Assert
     await expect(
       page.getByText("Sign in to save bookmarks"),
     ).toBeVisible();
+    await expectAccountAccessState(page);
   });
 
   test("bookmarks route redirects to login when not authenticated", async ({
@@ -68,6 +73,40 @@ test.describe("Navigation", () => {
     expect(page.url()).toContain("callbackUrl");
   });
 });
+
+/**
+ * Assert login page offers OAuth buttons or a clear provider-unavailable state.
+ * @param page - Playwright page currently on `/login`.
+ * @returns Promise that resolves when one account access state is visible.
+ * @example
+ * await expectAccountAccessState(page);
+ */
+async function expectAccountAccessState(page: Page) {
+  const githubButton = page.getByText("Continue with GitHub");
+  const googleButton = page.getByText("Continue with Google");
+  const unavailableMessage = page.getByText(
+    "Sign-in is temporarily unavailable",
+  );
+
+  const hasGitHubButton = await githubButton.isVisible().catch(() => false);
+  const hasGoogleButton = await googleButton.isVisible().catch(() => false);
+  const hasUnavailableMessage = await unavailableMessage
+    .isVisible()
+    .catch(() => false);
+
+  expect(
+    hasGitHubButton || hasGoogleButton || hasUnavailableMessage,
+  ).toBeTruthy();
+
+  if (hasUnavailableMessage) {
+    await expect(
+      page.getByText("Account sign-in is not configured yet."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Back to briefing" }),
+    ).toBeVisible();
+  }
+}
 
 test.describe("Theme Toggle", () => {
   test("theme toggle button is visible", async ({ page }) => {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,12 @@
-import { auth, signIn } from "@/lib/auth";
+import Link from "next/link";
 import { redirect } from "next/navigation";
+
+import {
+  auth,
+  authProviderAvailability,
+  hasAuthProvider,
+  signIn,
+} from "@/lib/auth";
 import { Button } from "@/components/ui/button";
 
 /**
@@ -31,45 +38,74 @@ export default async function LoginPage({
           </p>
         </div>
 
-        <div className="space-y-3">
-          <form
-            action={async () => {
-              "use server";
-              await signIn("github", { redirectTo });
-            }}
+        {hasAuthProvider ? (
+          <div className="space-y-3">
+            {authProviderAvailability.github && (
+              <form
+                action={async () => {
+                  "use server";
+                  await signIn("github", { redirectTo });
+                }}
+              >
+                <Button
+                  type="submit"
+                  variant="outline"
+                  size="lg"
+                  className="w-full cursor-pointer gap-3 border-ms-border bg-ms-bg-tertiary text-ms-text-primary hover:bg-ms-bg-primary"
+                >
+                  <GitHubIcon />
+                  Continue with GitHub
+                </Button>
+              </form>
+            )}
+
+            {authProviderAvailability.google && (
+              <form
+                action={async () => {
+                  "use server";
+                  await signIn("google", { redirectTo });
+                }}
+              >
+                <Button
+                  type="submit"
+                  variant="outline"
+                  size="lg"
+                  className="w-full cursor-pointer gap-3 border-ms-border bg-ms-bg-tertiary text-ms-text-primary hover:bg-ms-bg-primary"
+                >
+                  <GoogleIcon />
+                  Continue with Google
+                </Button>
+              </form>
+            )}
+          </div>
+        ) : (
+          <div
+            className="rounded-md border border-ms-border bg-ms-bg-tertiary p-4 text-center"
+            role="status"
           >
+            <p className="font-medium text-ms-text-primary">
+              Sign-in is temporarily unavailable
+            </p>
+            <p className="mt-2 text-sm text-ms-text-secondary">
+              Account sign-in is not configured yet. The public briefing is
+              still available.
+            </p>
             <Button
-              type="submit"
+              asChild
               variant="outline"
               size="lg"
-              className="w-full cursor-pointer gap-3 border-ms-border bg-ms-bg-tertiary text-ms-text-primary hover:bg-ms-bg-primary"
+              className="mt-4 w-full cursor-pointer border-ms-border bg-ms-bg-secondary text-ms-text-primary hover:bg-ms-bg-primary"
             >
-              <GitHubIcon />
-              Continue with GitHub
+              <Link href="/">Back to briefing</Link>
             </Button>
-          </form>
+          </div>
+        )}
 
-          <form
-            action={async () => {
-              "use server";
-              await signIn("google", { redirectTo });
-            }}
-          >
-            <Button
-              type="submit"
-              variant="outline"
-              size="lg"
-              className="w-full cursor-pointer gap-3 border-ms-border bg-ms-bg-tertiary text-ms-text-primary hover:bg-ms-bg-primary"
-            >
-              <GoogleIcon />
-              Continue with Google
-            </Button>
-          </form>
-        </div>
-
-        <p className="text-center text-xs text-ms-text-muted">
-          By signing in, you agree to our Terms of Service
-        </p>
+        {hasAuthProvider && (
+          <p className="text-center text-xs text-ms-text-muted">
+            By signing in, you agree to our Terms of Service
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,8 +6,12 @@ import { db } from "@/lib/db";
 import { users, accounts, sessions, verificationTokens } from "@/lib/db/schema";
 
 export const authProviderAvailability = {
-  github: Boolean(process.env.AUTH_GITHUB_ID && process.env.AUTH_GITHUB_SECRET),
-  google: Boolean(process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET),
+  github:
+    Boolean(process.env.AUTH_GITHUB_ID?.trim()) &&
+    Boolean(process.env.AUTH_GITHUB_SECRET?.trim()),
+  google:
+    Boolean(process.env.AUTH_GOOGLE_ID?.trim()) &&
+    Boolean(process.env.AUTH_GOOGLE_SECRET?.trim()),
 };
 
 export const hasAuthProvider =

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,19 @@ import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { db } from "@/lib/db";
 import { users, accounts, sessions, verificationTokens } from "@/lib/db/schema";
 
+export const authProviderAvailability = {
+  github: Boolean(process.env.AUTH_GITHUB_ID && process.env.AUTH_GITHUB_SECRET),
+  google: Boolean(process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET),
+};
+
+export const hasAuthProvider =
+  authProviderAvailability.github || authProviderAvailability.google;
+
+const providers = [
+  ...(authProviderAvailability.github ? [GitHub] : []),
+  ...(authProviderAvailability.google ? [Google] : []),
+];
+
 /**
  * Auth.js v5 configuration with Google and GitHub OAuth providers.
  * Uses Drizzle adapter for database session persistence in Supabase PostgreSQL.
@@ -21,7 +34,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     sessionsTable: sessions,
     verificationTokensTable: verificationTokens,
   }),
-  providers: [GitHub, Google],
+  providers,
   pages: {
     signIn: "/login",
   },


### PR DESCRIPTION
## Summary
- only register OAuth providers when both ID and secret env vars are configured
- show a clear sign-in unavailable state instead of broken provider buttons when OAuth env is absent
- update navigation e2e tests to cover both provider buttons and unavailable account access states

## Tests
- pnpm run typecheck && pnpm run lint && pnpm run build
- kill-port 3198 && pnpm run test:e2e -- e2e/home.spec.ts e2e/navigation.spec.ts

## Production note
- AUTH_SECRET and AUTH_TRUST_HOST are already configured in Vercel Production/Preview.
- Real OAuth sign-in still requires AUTH_GITHUB_ID/AUTH_GITHUB_SECRET or AUTH_GOOGLE_ID/AUTH_GOOGLE_SECRET to be added as Vercel env vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the login page to detect which authentication providers are available and only show the corresponding sign-in options. When none are configured, it now shows a “temporarily unavailable” message with a **“Back to briefing”** link, and hides Terms content until providers are available.

* **Tests**
  * Expanded and refined end-to-end coverage for the login flow, including navigation to `/login` and assertions for both “providers available” and “providers unavailable” states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->