### PR TITLE
v0.1.1 fix: restore production widget snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.1 - 2026-06-18
+
+- Persist weather and market widget snapshots to Supabase as a durable fallback when Redis is unavailable.
+- Refresh widget snapshots even when a manual or scheduled cron run skips an already-published edition.
+- Switch stock collection to the Yahoo Finance chart endpoint and keep partial market data when one symbol fails.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Widget data is collected alongside editions:
 
 | Widget | Source | Notes |
 | --- | --- | --- |
-| Weather | OpenWeatherMap | Cached as latest edition widget data when configured. |
-| Stocks | Market data source implementation | Cached as latest edition widget data when available. |
+| Weather | Open-Meteo Forecast API | No API key required. Cached in Redis when configured and persisted to Supabase `weather_cache`. |
+| Stocks | Yahoo Finance chart endpoint | Fetches Nikkei 225, S&P 500, and NASDAQ. Cached in Redis when configured and persisted to Supabase `stock_cache`. |
 
 ## Data Flow
 
@@ -76,7 +76,7 @@ Widget data is collected alongside editions:
 7. Scores are normalized and top items are selected.
 8. Articles are inserted into Supabase Postgres through Drizzle.
 9. The edition is marked `published`.
-10. Weather and stock widget data is cached through Upstash Redis when available.
+10. Weather and stock widget data is cached through Upstash Redis when available and persisted to Supabase widget cache tables as a durable fallback.
 
 ## Auth And Personalization
 
@@ -127,7 +127,6 @@ Signed-in features:
 | `GITHUB_TOKEN` | Optional | Raises GitHub API rate limits for PR collection. |
 | `YOUTUBE_API_KEY` | Optional | Enables YouTube Science & Technology video collection. |
 | `PRODUCTHUNT_API_TOKEN` | Optional | Enables Product Hunt launch collection. |
-| `OPENWEATHERMAP_API_KEY` | Optional | Enables weather widget collection. |
 
 Sources that require optional API keys degrade gracefully by returning cached data or an empty result.
 

--- a/e2e/stock-source.spec.ts
+++ b/e2e/stock-source.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test } from "@playwright/test";
+
+import { fetchStockData } from "../src/lib/sources/stocks";
+
+const originalFetch = globalThis.fetch;
+const originalConsoleError = console.error;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.error = originalConsoleError;
+});
+
+test.describe("Stock Source", () => {
+  test("normalizes Yahoo chart snapshots for the market widget", async () => {
+    // Arrange
+    const requestedSymbols: string[] = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(String(input));
+      const symbol = decodeURIComponent(url.pathname.split("/").at(-1) ?? "");
+      requestedSymbols.push(symbol);
+
+      return new Response(JSON.stringify(buildYahooChartResponse(symbol)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    // Act
+    const stocks = await fetchStockData();
+
+    // Assert
+    expect(requestedSymbols).toEqual(["^N225", "^GSPC", "^IXIC"]);
+    expect(stocks).toEqual([
+      {
+        symbol: "^N225",
+        name: "Nikkei 225",
+        price: 38600.5,
+        changeAmount: 300.25,
+        changePercent: 0.78,
+        currency: "JPY",
+      },
+      {
+        symbol: "^GSPC",
+        name: "S&P 500",
+        price: 6045.25,
+        changeAmount: -24.75,
+        changePercent: -0.41,
+        currency: "USD",
+      },
+      {
+        symbol: "^IXIC",
+        name: "NASDAQ",
+        price: 21111.46,
+        changeAmount: 111.46,
+        changePercent: 0.53,
+        currency: "USD",
+      },
+    ]);
+  });
+
+  test("returns an empty market snapshot when Yahoo chart requests fail", async () => {
+    // Arrange
+    console.error = () => undefined;
+    globalThis.fetch = async () =>
+      new Response("Unavailable", {
+        status: 503,
+        headers: { "Content-Type": "text/plain" },
+      });
+
+    // Act
+    const stocks = await fetchStockData();
+
+    // Assert
+    expect(stocks).toEqual([]);
+  });
+
+  test("keeps successful market snapshots when one Yahoo symbol fails", async () => {
+    // Arrange
+    console.error = () => undefined;
+    globalThis.fetch = async (input) => {
+      const url = new URL(String(input));
+      const symbol = decodeURIComponent(url.pathname.split("/").at(-1) ?? "");
+
+      if (symbol === "^IXIC") {
+        return new Response("Unavailable", { status: 503 });
+      }
+
+      return new Response(JSON.stringify(buildYahooChartResponse(symbol)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    // Act
+    const stocks = await fetchStockData();
+
+    // Assert
+    expect(stocks.map((stock) => stock.symbol)).toEqual(["^N225", "^GSPC"]);
+  });
+});
+
+/**
+ * Builds symbol-specific Yahoo chart fixtures so fetchStockData exercises each branch.
+ * @param symbol - Yahoo Finance symbol requested by the source fetcher.
+ * @returns Minimal chart response shape used by the source mapper.
+ * @example
+ * buildYahooChartResponse("^GSPC");
+ */
+function buildYahooChartResponse(symbol: string) {
+  if (symbol === "^N225") {
+    return {
+      chart: {
+        result: [
+          {
+            meta: {
+              currency: "JPY",
+              symbol,
+              regularMarketPrice: 38600.5,
+              chartPreviousClose: 38300.25,
+            },
+            indicators: { quote: [{ close: [38300.25, 38600.5] }] },
+          },
+        ],
+        error: null,
+      },
+    };
+  }
+
+  if (symbol === "^GSPC") {
+    return {
+      chart: {
+        result: [
+          {
+            meta: {
+              currency: "USD",
+              symbol,
+              regularMarketPrice: 6045.25,
+              chartPreviousClose: 6070,
+            },
+            indicators: { quote: [{ close: [6070, 6045.25] }] },
+          },
+        ],
+        error: null,
+      },
+    };
+  }
+
+  return {
+    chart: {
+      result: [
+        {
+          meta: {
+            currency: "USD",
+            symbol,
+          },
+          indicators: { quote: [{ close: [21000, null, 21111.456] }] },
+        },
+      ],
+      error: null,
+    },
+  };
+}

--- a/e2e/stock-source.spec.ts
+++ b/e2e/stock-source.spec.ts
@@ -26,7 +26,7 @@ test.describe("Stock Source", () => {
     };
 
     // Act
-    const stocks = await fetchStockData();
+    const stocks = await fetchStockData({ useCache: false });
 
     // Assert
     expect(requestedSymbols).toEqual(["^N225", "^GSPC", "^IXIC"]);
@@ -68,7 +68,7 @@ test.describe("Stock Source", () => {
       });
 
     // Act
-    const stocks = await fetchStockData();
+    const stocks = await fetchStockData({ useCache: false });
 
     // Assert
     expect(stocks).toEqual([]);
@@ -92,7 +92,7 @@ test.describe("Stock Source", () => {
     };
 
     // Act
-    const stocks = await fetchStockData();
+    const stocks = await fetchStockData({ useCache: false });
 
     // Assert
     expect(stocks.map((stock) => stock.symbol)).toEqual(["^N225", "^GSPC"]);

--- a/e2e/widget-snapshots.spec.ts
+++ b/e2e/widget-snapshots.spec.ts
@@ -6,23 +6,30 @@ import {
 } from "../src/lib/widget-snapshots";
 
 test.describe("Widget Snapshots", () => {
-  test("returns empty widgets without touching a placeholder database", async () => {
-    // Arrange / Act
-    const widgets = await getCachedOrPersistedWidgetData();
+  test("returns empty widgets when external reads are disabled", async () => {
+    // Arrange
+    const externalReadsDisabled = { useCache: false, useDatabase: false };
+
+    // Act
+    const widgets = await getCachedOrPersistedWidgetData({
+      ...externalReadsDisabled,
+    });
 
     // Assert
     expect(widgets).toEqual({ weather: null, stocks: [] });
   });
 
-  test("ignores Supabase persistence when no runtime database is configured", async () => {
+  test("completes when external writes are disabled", async () => {
     // Arrange
-    let didSaveWithoutDatabase = false;
+    const externalWritesDisabled = { useCache: false, useDatabase: false };
 
     // Act
-    await saveWidgetSnapshots({ weather: null, stocks: [] });
-    didSaveWithoutDatabase = true;
+    const saveResult = saveWidgetSnapshots(
+      { weather: null, stocks: [] },
+      { ...externalWritesDisabled },
+    );
 
     // Assert
-    expect(didSaveWithoutDatabase).toBe(true);
+    await expect(saveResult).resolves.toBeUndefined();
   });
 });

--- a/e2e/widget-snapshots.spec.ts
+++ b/e2e/widget-snapshots.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  getCachedOrPersistedWidgetData,
+  saveWidgetSnapshots,
+} from "../src/lib/widget-snapshots";
+
+test.describe("Widget Snapshots", () => {
+  test("returns empty widgets without touching a placeholder database", async () => {
+    // Arrange / Act
+    const widgets = await getCachedOrPersistedWidgetData();
+
+    // Assert
+    expect(widgets).toEqual({ weather: null, stocks: [] });
+  });
+
+  test("ignores Supabase persistence when no runtime database is configured", async () => {
+    // Arrange
+    let didSaveWithoutDatabase = false;
+
+    // Act
+    await saveWidgetSnapshots({ weather: null, stocks: [] });
+    didSaveWithoutDatabase = true;
+
+    // Assert
+    expect(didSaveWithoutDatabase).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-stack",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "packageManager": "pnpm@11.6.0",
   "scripts": {

--- a/src/lib/cron/edition-collector.ts
+++ b/src/lib/cron/edition-collector.ts
@@ -15,7 +15,7 @@ import { fetchProductHuntArticles } from "@/lib/sources/producthunt";
 import { fetchGitHubPRs } from "@/lib/sources/github-prs";
 import { fetchWeather } from "@/lib/sources/weather";
 import { fetchStockData } from "@/lib/sources/stocks";
-import { cacheSet } from "@/lib/cache";
+import { saveWidgetSnapshots } from "@/lib/widget-snapshots";
 
 /** Edition type produced by the twice-daily collector. */
 export type EditionType = "morning" | "evening";
@@ -68,12 +68,6 @@ const SCORE_RANGES: Record<ArticleSource, { min: number; max: number }> = {
   world_news: { min: 0, max: 100 },
 };
 
-/** Cache key for latest edition widget data (weather/stocks). */
-const WIDGET_CACHE_KEY = "edition:widgets";
-
-/** Widget cache duration: 30 minutes. */
-const WIDGET_CACHE_TTL = 30 * 60;
-
 /**
  * Convert a route segment into an edition type for split Vercel cron paths.
  * @param value - Dynamic route segment from `/api/cron/collect/[edition]`.
@@ -115,6 +109,10 @@ export async function handleCollectRequest(
 
     const existingEdition = await findExistingEdition(editionType, today);
     if (existingEdition?.status === "published") {
+      const { weatherData, stockData } = await fetchWidgetSources();
+      const widgetResults = getWidgetSourceResults(weatherData, stockData);
+      await saveWidgetSnapshots({ weather: weatherData, stocks: stockData });
+
       console.log(
         `[Cron] ${editionType} edition for ${today} already published (${existingEdition.id}), skipping`,
       );
@@ -124,6 +122,7 @@ export async function handleCollectRequest(
         editionId: existingEdition.id,
         editionType,
         date: today,
+        widgets: widgetResults,
       });
     }
 
@@ -158,25 +157,8 @@ export async function handleCollectRequest(
       })),
     );
 
-    sourceResults.push({
-      source: "weather",
-      status: weatherData ? "success" : "failure",
-      count: weatherData ? 1 : 0,
-      error: weatherData ? undefined : "No data",
-    });
-
-    sourceResults.push({
-      source: "stocks",
-      status: stockData.length > 0 ? "success" : "failure",
-      count: stockData.length,
-      error: stockData.length > 0 ? undefined : "No data",
-    });
-
-    await cacheSet(
-      WIDGET_CACHE_KEY,
-      { weather: weatherData, stocks: stockData },
-      WIDGET_CACHE_TTL,
-    );
+    sourceResults.push(...getWidgetSourceResults(weatherData, stockData));
+    await saveWidgetSnapshots({ weather: weatherData, stocks: stockData });
 
     await db
       .update(editions)
@@ -368,6 +350,56 @@ async function fetchAllSources(): Promise<{
       weatherResult.status === "fulfilled" ? weatherResult.value : null,
     stockData: stockResult.status === "fulfilled" ? stockResult.value : [],
   };
+}
+
+/**
+ * Fetch only weather and stock widgets for a skipped already-published edition.
+ * @returns Current widget source data, using empty values when a source fails.
+ * @example
+ * const widgets = await fetchWidgetSources();
+ */
+async function fetchWidgetSources(): Promise<{
+  weatherData: Awaited<ReturnType<typeof fetchWeather>>;
+  stockData: Awaited<ReturnType<typeof fetchStockData>>;
+}> {
+  const [weatherResult, stockResult] = await Promise.allSettled([
+    fetchWeather(),
+    fetchStockData(),
+  ]);
+
+  return {
+    weatherData:
+      weatherResult.status === "fulfilled" ? weatherResult.value : null,
+    stockData: stockResult.status === "fulfilled" ? stockResult.value : [],
+  };
+}
+
+/**
+ * Convert widget values into source status entries for cron responses.
+ * @param weatherData - Weather snapshot, or null when unavailable.
+ * @param stockData - Stock snapshots, or an empty array when unavailable.
+ * @returns Source results for weather and stocks.
+ * @example
+ * getWidgetSourceResults(weatherData, stockData);
+ */
+function getWidgetSourceResults(
+  weatherData: Awaited<ReturnType<typeof fetchWeather>>,
+  stockData: Awaited<ReturnType<typeof fetchStockData>>,
+): SourceResult[] {
+  return [
+    {
+      source: "weather",
+      status: weatherData ? "success" : "failure",
+      count: weatherData ? 1 : 0,
+      error: weatherData ? undefined : "No data",
+    },
+    {
+      source: "stocks",
+      status: stockData.length > 0 ? "success" : "failure",
+      count: stockData.length,
+      error: stockData.length > 0 ? undefined : "No data",
+    },
+  ];
 }
 
 /**

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -37,3 +37,15 @@ const postgresClient = postgres(resolvedDatabaseUrl, {
 export const db: PostgresJsDatabase<typeof schema> = drizzle(postgresClient, {
   schema,
 });
+
+/**
+ * Tells optional runtime features whether a real database connection is present.
+ * @returns
+ * - `true`: Runtime has a non-placeholder DATABASE_URL.
+ * - `false`: Local/build fallback is using the construction-only placeholder.
+ * @example
+ * if (!isRuntimeDatabaseConfigured()) return;
+ */
+export function isRuntimeDatabaseConfigured(): boolean {
+  return Boolean(databaseUrl && databaseUrl !== BUILD_ONLY_DATABASE_URL);
+}

--- a/src/lib/queries/edition.ts
+++ b/src/lib/queries/edition.ts
@@ -3,10 +3,11 @@ import { eq, and, desc } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { editions, articles, hiddenItems } from "@/lib/db/schema";
 import { auth } from "@/lib/auth";
-import { cacheGet } from "@/lib/cache";
+import {
+  getCachedOrPersistedWidgetData,
+  type WidgetData,
+} from "@/lib/widget-snapshots";
 import type { Article, ArticleSource } from "@/types/article";
-import type { WeatherData } from "@/lib/sources/weather";
-import type { StockData } from "@/lib/sources/stocks";
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -23,17 +24,6 @@ export interface EditionData {
   /** Flat list of all articles (for the hero section). */
   allArticles: Article[];
 }
-
-/** Cached widget data shape (matches the cron collection output). */
-export interface WidgetData {
-  weather: WeatherData | null;
-  stocks: StockData[];
-}
-
-// ─── Constants ──────────────────────────────────────────────────────
-
-/** Redis key used by the cron collector for widget data. */
-const WIDGET_CACHE_KEY = "edition:widgets";
 
 // ─── Public API ─────────────────────────────────────────────────────
 
@@ -144,8 +134,7 @@ export async function getLatestEdition(): Promise<EditionData | null> {
  * Returns null weather and empty stocks array when cache is empty.
  */
 export async function getWidgetData(): Promise<WidgetData> {
-  const cached = await cacheGet<WidgetData>(WIDGET_CACHE_KEY);
-  return cached ?? { weather: null, stocks: [] };
+  return getCachedOrPersistedWidgetData();
 }
 
 // ─── Internal Helpers ────────────────────────────────────────────────

--- a/src/lib/sources/stocks.ts
+++ b/src/lib/sources/stocks.ts
@@ -53,6 +53,12 @@ export interface StockData {
   currency: string;
 }
 
+/** Controls external cache use for production calls and isolated tests. */
+export interface StockFetchOptions {
+  /** Read/write Redis cache and use stale-cache fallback when true. */
+  useCache?: boolean;
+}
+
 // ─── Constants ──────────────────────────────────────────────────────
 
 /**
@@ -94,13 +100,22 @@ const CACHE_TTL_MARKET_CLOSED = 6 * 60 * 60;
  * - 15 minutes when JPX (Nikkei) or NYSE/NASDAQ is open.
  * - 6 hours when all markets are closed.
  *
+ * @param options - Cache policy for callers that must isolate external state.
  * @returns Array of {@link StockData}, or empty array if unavailable.
  * @throws Never — returns `[]` as a last resort.
+ * @example
+ * await fetchStockData({ useCache: false });
  */
-export async function fetchStockData(): Promise<StockData[]> {
+export async function fetchStockData(
+  options: StockFetchOptions = {},
+): Promise<StockData[]> {
+  const { useCache = true } = options;
+
   // 1. Try cache first
-  const cached = await cacheGet<StockData[]>(CACHE_KEY);
-  if (cached) return cached;
+  if (useCache) {
+    const cached = await cacheGet<StockData[]>(CACHE_KEY);
+    if (cached) return cached;
+  }
 
   try {
     const stockResults = await Promise.allSettled(
@@ -114,16 +129,22 @@ export async function fetchStockData(): Promise<StockData[]> {
 
     const ttl = getMarketAwareTTL();
 
-    // Write to cache (fire-and-forget — don't block the response)
-    void cacheSet(CACHE_KEY, stocks, ttl);
+    // Cache failures should not hide fresh market data.
+    if (useCache) {
+      void cacheSet(CACHE_KEY, stocks, ttl).catch((error: unknown) => {
+        console.error("[Stocks] Cache write failed:", error);
+      });
+    }
 
     return stocks;
   } catch (error) {
     console.error("[Stocks] Fetch failed, trying stale cache:", error);
 
     // 3. Fallback: re-read cache in case a prior request populated it
-    const stale = await cacheGet<StockData[]>(CACHE_KEY);
-    if (stale) return stale;
+    if (useCache) {
+      const stale = await cacheGet<StockData[]>(CACHE_KEY);
+      if (stale) return stale;
+    }
 
     return [];
   }
@@ -234,7 +255,14 @@ function mapChartToStockData(
  * getLatestClose([100, null, 101]);
  */
 function getLatestClose(closes?: Array<number | null>): number | undefined {
-  return closes?.findLast((close): close is number => typeof close === "number");
+  if (!closes) return undefined;
+
+  for (let index = closes.length - 1; index >= 0; index -= 1) {
+    const close = closes[index];
+    if (typeof close === "number") return close;
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/lib/sources/stocks.ts
+++ b/src/lib/sources/stocks.ts
@@ -1,22 +1,32 @@
 import { cacheGet, cacheSet } from "@/lib/cache";
 
-// ─── Yahoo Finance API types ────────────────────────────────────────
+// ─── Yahoo Finance Chart API types ──────────────────────────────────
 
-/** Relevant fields from a single Yahoo Finance quote result. */
-interface YFQuoteResult {
-  symbol: string;
-  shortName?: string;
-  regularMarketPrice?: number;
-  regularMarketChange?: number;
-  regularMarketChangePercent?: number;
+/** Relevant metadata from a single Yahoo Finance chart result. */
+interface YFChartMeta {
   currency?: string;
+  symbol: string;
+  regularMarketPrice?: number;
+  chartPreviousClose?: number;
+  longName?: string;
+  shortName?: string;
 }
 
-/** Shape of the Yahoo Finance v8 quote response. */
-interface YFQuoteResponse {
-  quoteResponse: {
-    result: YFQuoteResult[];
-    error: unknown;
+/** Shape of the Yahoo Finance v8 chart response for one index. */
+interface YFChartResponse {
+  chart: {
+    result: Array<{
+      meta: YFChartMeta;
+      indicators: {
+        quote: Array<{
+          close?: Array<number | null>;
+        }>;
+      };
+    }> | null;
+    error: null | {
+      code?: string;
+      description?: string;
+    };
   };
 }
 
@@ -46,12 +56,12 @@ export interface StockData {
 // ─── Constants ──────────────────────────────────────────────────────
 
 /**
- * Yahoo Finance v8 public quote endpoint.
+ * Yahoo Finance v8 public chart endpoint.
  *
- * Accepts a comma-separated `symbols` parameter and returns batch
- * quote data without requiring an API key.
+ * The quote endpoint now returns 401 for unauthenticated requests in many
+ * environments, while the chart endpoint still returns public index metadata.
  */
-const YF_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote";
+const YF_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart";
 
 const CACHE_KEY = "source:stocks";
 
@@ -77,7 +87,7 @@ const CACHE_TTL_MARKET_CLOSED = 6 * 60 * 60;
  * Fetch current stock index data for Nikkei 225, S&P 500, and NASDAQ.
  *
  * 1. Returns cached data if available.
- * 2. On cache miss, fetches from Yahoo Finance API and caches the result.
+ * 2. On cache miss, fetches from Yahoo Finance chart API and caches the result.
  * 3. On API failure, falls back to stale cached data if any exists.
  *
  * Cache TTL is market-hours-aware:
@@ -92,30 +102,16 @@ export async function fetchStockData(): Promise<StockData[]> {
   const cached = await cacheGet<StockData[]>(CACHE_KEY);
   if (cached) return cached;
 
-  // 2. Fetch from Yahoo Finance
   try {
-    const symbols = INDEX_SYMBOLS.join(",");
-    const url = `${YF_QUOTE_URL}?symbols=${symbols}`;
-    const res = await fetch(url, {
-      headers: {
-        "User-Agent": "MorningStack/1.0",
-      },
-      next: { revalidate: 0 },
-    });
+    const stockResults = await Promise.allSettled(
+      INDEX_SYMBOLS.map(fetchIndexChart),
+    );
+    const stocks = collectFulfilledStocks(stockResults);
 
-    if (!res.ok) {
-      throw new Error(`Yahoo Finance API responded with ${res.status}`);
+    if (stocks.length === 0) {
+      throw new Error("Yahoo Finance chart API returned no stock snapshots");
     }
 
-    const data: YFQuoteResponse = await res.json();
-
-    if (data.quoteResponse.error) {
-      throw new Error(
-        `Yahoo Finance API error: ${JSON.stringify(data.quoteResponse.error)}`,
-      );
-    }
-
-    const stocks = data.quoteResponse.result.map(mapQuoteToStockData);
     const ttl = getMarketAwareTTL();
 
     // Write to cache (fire-and-forget — don't block the response)
@@ -136,17 +132,126 @@ export async function fetchStockData(): Promise<StockData[]> {
 // ─── Internal helpers ───────────────────────────────────────────────
 
 /**
- * Map a Yahoo Finance quote result to the normalized {@link StockData} shape.
+ * Keep successful index snapshots even when another Yahoo symbol fails.
+ * @param results - Per-symbol chart fetch results in INDEX_SYMBOLS order.
+ * @returns Successfully mapped stock snapshots.
+ * @example
+ * collectFulfilledStocks(results);
  */
-function mapQuoteToStockData(quote: YFQuoteResult): StockData {
+function collectFulfilledStocks(
+  results: PromiseSettledResult<StockData | null>[],
+): StockData[] {
+  const stocks: StockData[] = [];
+
+  for (const [symbolIndex, result] of results.entries()) {
+    if (result.status === "fulfilled") {
+      if (result.value) stocks.push(result.value);
+      continue;
+    }
+
+    // A single index should not hide the other market snapshots.
+    console.error(
+      `[Stocks] ${INDEX_SYMBOLS[symbolIndex]} chart fetch failed:`,
+      result.reason,
+    );
+  }
+
+  return stocks;
+}
+
+/**
+ * Fetch one index through Yahoo Finance chart metadata.
+ * @param symbol - Yahoo Finance index symbol.
+ * @returns Normalized stock data, or null when the index cannot be mapped.
+ * @example
+ * await fetchIndexChart("^GSPC");
+ */
+async function fetchIndexChart(
+  symbol: (typeof INDEX_SYMBOLS)[number],
+): Promise<StockData | null> {
+  const url = `${YF_CHART_URL}/${encodeURIComponent(symbol)}?range=5d&interval=1d`;
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": "MorningStack/1.0",
+    },
+    next: { revalidate: 0 },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Yahoo Finance chart API responded with ${res.status}`);
+  }
+
+  const data: YFChartResponse = await res.json();
+
+  if (data.chart.error) {
+    throw new Error(
+      `Yahoo Finance chart API error: ${JSON.stringify(data.chart.error)}`,
+    );
+  }
+
+  const result = data.chart.result?.[0];
+  if (!result) return null;
+
+  return mapChartToStockData(symbol, result.meta, result.indicators.quote[0]);
+}
+
+/**
+ * Map Yahoo Finance chart metadata to the normalized {@link StockData} shape.
+ * @param symbol - Requested Yahoo Finance index symbol.
+ * @param meta - Chart metadata containing current and previous close prices.
+ * @param quote - Quote arrays used as a fallback when metadata is incomplete.
+ * @returns Normalized stock data for one index.
+ * @example
+ * mapChartToStockData("^GSPC", meta, quote);
+ */
+function mapChartToStockData(
+  symbol: (typeof INDEX_SYMBOLS)[number],
+  meta: YFChartMeta,
+  quote?: { close?: Array<number | null> },
+): StockData {
+  const price = meta.regularMarketPrice ?? getLatestClose(quote?.close) ?? 0;
+  const previousClose =
+    meta.chartPreviousClose ?? getPreviousClose(quote?.close) ?? price;
+  const changeAmount = price - previousClose;
+  const changePercent =
+    previousClose === 0 ? 0 : (changeAmount / previousClose) * 100;
+
   return {
-    symbol: quote.symbol,
-    name: SYMBOL_NAMES[quote.symbol] ?? quote.shortName ?? quote.symbol,
-    price: quote.regularMarketPrice ?? 0,
-    changeAmount: roundTo2(quote.regularMarketChange ?? 0),
-    changePercent: roundTo2(quote.regularMarketChangePercent ?? 0),
-    currency: quote.currency ?? "USD",
+    symbol,
+    name: SYMBOL_NAMES[symbol] ?? meta.shortName ?? meta.longName ?? symbol,
+    price: roundTo2(price),
+    changeAmount: roundTo2(changeAmount),
+    changePercent: roundTo2(changePercent),
+    currency: meta.currency ?? "USD",
   };
+}
+
+/**
+ * Return the latest numeric close from a Yahoo chart close array.
+ * @param closes - Close values from the chart API.
+ * @returns Latest valid close, or undefined when none exists.
+ * @example
+ * getLatestClose([100, null, 101]);
+ */
+function getLatestClose(closes?: Array<number | null>): number | undefined {
+  return closes?.findLast((close): close is number => typeof close === "number");
+}
+
+/**
+ * Return the close immediately before the latest valid close.
+ * @param closes - Close values from the chart API.
+ * @returns Previous valid close, or undefined when none exists.
+ * @example
+ * getPreviousClose([100, 101]);
+ */
+function getPreviousClose(closes?: Array<number | null>): number | undefined {
+  const validCloses = closes?.filter(
+    (close): close is number => typeof close === "number",
+  );
+
+  if (!validCloses || validCloses.length < 2) return undefined;
+
+  return validCloses[validCloses.length - 2];
 }
 
 /**
@@ -192,6 +297,10 @@ function getMarketAwareTTL(): number {
 
 /**
  * Round a number to 2 decimal places.
+ * @param n - Number to round.
+ * @returns Number rounded to two decimal places.
+ * @example
+ * roundTo2(1.234);
  */
 function roundTo2(n: number): number {
   return Math.round(n * 100) / 100;

--- a/src/lib/widget-snapshots.ts
+++ b/src/lib/widget-snapshots.ts
@@ -1,0 +1,167 @@
+import { desc } from "drizzle-orm";
+
+import { cacheGet, cacheSet } from "@/lib/cache";
+import { db, isRuntimeDatabaseConfigured } from "@/lib/db";
+import { stockCache, weatherCache } from "@/lib/db/schema";
+import type { StockData } from "@/lib/sources/stocks";
+import type { WeatherData } from "@/lib/sources/weather";
+
+/** Cached widget data shape shared by cron collection and home page rendering. */
+export interface WidgetData {
+  weather: WeatherData | null;
+  stocks: StockData[];
+}
+
+/** Redis key used by the cron collector for latest edition widget data. */
+export const WIDGET_CACHE_KEY = "edition:widgets";
+
+/** Keep widget snapshots alive until the next twice-daily edition has time to publish. */
+export const WIDGET_CACHE_TTL = 24 * 60 * 60;
+
+/** Preferred stock display order for persisted cache reads. */
+const STOCK_SYMBOL_ORDER = ["^N225", "^GSPC", "^IXIC"];
+
+/**
+ * Store widget snapshots in Redis and Supabase so widgets survive Redis misses.
+ * @param widgetData - Weather and stocks fetched during cron or manual refresh.
+ * @returns Resolves after best-effort persistence attempts finish.
+ * @example
+ * await saveWidgetSnapshots({ weather, stocks });
+ */
+export async function saveWidgetSnapshots(
+  widgetData: WidgetData,
+): Promise<void> {
+  const tasks = [
+    cacheSet(WIDGET_CACHE_KEY, widgetData, WIDGET_CACHE_TTL),
+    saveWeatherSnapshot(widgetData.weather),
+    saveStockSnapshots(widgetData.stocks),
+  ];
+
+  const results = await Promise.allSettled(tasks);
+
+  // Widget data is nice-to-have; never fail the edition publish for cache writes.
+  for (const result of results) {
+    if (result.status === "rejected") {
+      console.error("[Widgets] Snapshot persistence failed:", result.reason);
+    }
+  }
+}
+
+/**
+ * Read widget data from Redis first, then fall back to the latest Supabase rows.
+ * @returns Latest widget data, or empty unavailable values when no snapshot exists.
+ * @example
+ * const widgets = await getCachedOrPersistedWidgetData();
+ */
+export async function getCachedOrPersistedWidgetData(): Promise<WidgetData> {
+  const cached = await cacheGet<WidgetData>(WIDGET_CACHE_KEY);
+  if (cached) return cached;
+
+  const persisted = await getPersistedWidgetSnapshots();
+
+  // Repopulate Redis when possible so repeated page renders stay cheap.
+  if (persisted.weather || persisted.stocks.length > 0) {
+    void cacheSet(WIDGET_CACHE_KEY, persisted, WIDGET_CACHE_TTL);
+  }
+
+  return persisted;
+}
+
+/**
+ * Store the latest weather snapshot in the existing Supabase cache table.
+ * @param weather - Weather data from the source fetcher, or null on failure.
+ * @returns Resolves when the row is inserted or when there is nothing to save.
+ * @example
+ * await saveWeatherSnapshot(weather);
+ */
+async function saveWeatherSnapshot(weather: WeatherData | null): Promise<void> {
+  if (!isRuntimeDatabaseConfigured()) return;
+  if (!weather) return;
+
+  await db.insert(weatherCache).values({
+    location: weather.city,
+    data: weather,
+    fetchedAt: new Date(),
+  });
+}
+
+/**
+ * Store one Supabase cache row for each stock index snapshot.
+ * @param stocks - Stock index data from the source fetcher.
+ * @returns Resolves when rows are inserted or when there is nothing to save.
+ * @example
+ * await saveStockSnapshots(stocks);
+ */
+async function saveStockSnapshots(stocks: StockData[]): Promise<void> {
+  if (!isRuntimeDatabaseConfigured()) return;
+  if (stocks.length === 0) return;
+
+  await db.insert(stockCache).values(
+    stocks.map((stock) => ({
+      symbol: stock.symbol,
+      data: stock,
+      fetchedAt: new Date(),
+    })),
+  );
+}
+
+/**
+ * Load the most recent weather row and most recent row per stock symbol.
+ * @returns Widget data reconstructed from Supabase cache rows.
+ * @example
+ * const persisted = await getPersistedWidgetSnapshots();
+ */
+async function getPersistedWidgetSnapshots(): Promise<WidgetData> {
+  if (!isRuntimeDatabaseConfigured()) {
+    return { weather: null, stocks: [] };
+  }
+
+  try {
+    const [weatherRows, stockRows] = await Promise.all([
+      db
+        .select({ data: weatherCache.data })
+        .from(weatherCache)
+        .orderBy(desc(weatherCache.fetchedAt))
+        .limit(1),
+      db
+        .select({ symbol: stockCache.symbol, data: stockCache.data })
+        .from(stockCache)
+        .orderBy(desc(stockCache.fetchedAt))
+        .limit(30),
+    ]);
+
+    const stocksBySymbol = new Map<string, StockData>();
+    for (const row of stockRows) {
+      // Rows are newest-first, so the first row per symbol is the latest snapshot.
+      if (!stocksBySymbol.has(row.symbol)) {
+        stocksBySymbol.set(row.symbol, row.data as StockData);
+      }
+    }
+
+    return {
+      weather: (weatherRows[0]?.data as WeatherData | undefined) ?? null,
+      stocks: sortStocks(Array.from(stocksBySymbol.values())),
+    };
+  } catch (error) {
+    console.error("[Widgets] Failed to load persisted snapshots:", error);
+    return { weather: null, stocks: [] };
+  }
+}
+
+/**
+ * Sort stock snapshots into the expected widget display order.
+ * @param stocks - Unordered stock snapshots loaded from persistence.
+ * @returns Stocks ordered by Nikkei, S&P 500, then NASDAQ.
+ * @example
+ * sortStocks(stocks);
+ */
+function sortStocks(stocks: StockData[]): StockData[] {
+  return stocks.toSorted((a, b) => {
+    const aIndex = STOCK_SYMBOL_ORDER.indexOf(a.symbol);
+    const bIndex = STOCK_SYMBOL_ORDER.indexOf(b.symbol);
+    const normalizedA = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex;
+    const normalizedB = bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex;
+
+    return normalizedA - normalizedB;
+  });
+}

--- a/src/lib/widget-snapshots.ts
+++ b/src/lib/widget-snapshots.ts
@@ -12,6 +12,22 @@ export interface WidgetData {
   stocks: StockData[];
 }
 
+/** Controls external persistence use for production calls and isolated tests. */
+export interface WidgetSnapshotSaveOptions {
+  /** Write the latest widget payload to Redis when true. */
+  useCache?: boolean;
+  /** Write widget payload rows to Supabase when true. */
+  useDatabase?: boolean;
+}
+
+/** Controls external reads for the home page and isolated tests. */
+export interface WidgetSnapshotReadOptions {
+  /** Read and repopulate Redis cache when true. */
+  useCache?: boolean;
+  /** Read the durable Supabase fallback when true. */
+  useDatabase?: boolean;
+}
+
 /** Redis key used by the cron collector for latest edition widget data. */
 export const WIDGET_CACHE_KEY = "edition:widgets";
 
@@ -24,18 +40,26 @@ const STOCK_SYMBOL_ORDER = ["^N225", "^GSPC", "^IXIC"];
 /**
  * Store widget snapshots in Redis and Supabase so widgets survive Redis misses.
  * @param widgetData - Weather and stocks fetched during cron or manual refresh.
+ * @param options - Persistence policy for callers that must isolate external state.
  * @returns Resolves after best-effort persistence attempts finish.
  * @example
- * await saveWidgetSnapshots({ weather, stocks });
+ * await saveWidgetSnapshots({ weather, stocks }, { useCache: false });
  */
 export async function saveWidgetSnapshots(
   widgetData: WidgetData,
+  options: WidgetSnapshotSaveOptions = {},
 ): Promise<void> {
-  const tasks = [
-    cacheSet(WIDGET_CACHE_KEY, widgetData, WIDGET_CACHE_TTL),
-    saveWeatherSnapshot(widgetData.weather),
-    saveStockSnapshots(widgetData.stocks),
-  ];
+  const { useCache = true, useDatabase = true } = options;
+  const tasks: Array<Promise<void>> = [];
+
+  if (useCache) {
+    tasks.push(cacheSet(WIDGET_CACHE_KEY, widgetData, WIDGET_CACHE_TTL));
+  }
+
+  if (useDatabase) {
+    tasks.push(saveWeatherSnapshot(widgetData.weather));
+    tasks.push(saveStockSnapshots(widgetData.stocks));
+  }
 
   const results = await Promise.allSettled(tasks);
 
@@ -49,19 +73,32 @@ export async function saveWidgetSnapshots(
 
 /**
  * Read widget data from Redis first, then fall back to the latest Supabase rows.
+ * @param options - Read policy for callers that must isolate external state.
  * @returns Latest widget data, or empty unavailable values when no snapshot exists.
  * @example
- * const widgets = await getCachedOrPersistedWidgetData();
+ * const widgets = await getCachedOrPersistedWidgetData({ useCache: false });
  */
-export async function getCachedOrPersistedWidgetData(): Promise<WidgetData> {
-  const cached = await cacheGet<WidgetData>(WIDGET_CACHE_KEY);
-  if (cached) return cached;
+export async function getCachedOrPersistedWidgetData(
+  options: WidgetSnapshotReadOptions = {},
+): Promise<WidgetData> {
+  const { useCache = true, useDatabase = true } = options;
 
-  const persisted = await getPersistedWidgetSnapshots();
+  if (useCache) {
+    const cached = await cacheGet<WidgetData>(WIDGET_CACHE_KEY);
+    if (cached) return cached;
+  }
+
+  const persisted = useDatabase
+    ? await getPersistedWidgetSnapshots()
+    : { weather: null, stocks: [] };
 
   // Repopulate Redis when possible so repeated page renders stay cheap.
-  if (persisted.weather || persisted.stocks.length > 0) {
-    void cacheSet(WIDGET_CACHE_KEY, persisted, WIDGET_CACHE_TTL);
+  if (useCache && (persisted.weather || persisted.stocks.length > 0)) {
+    void cacheSet(WIDGET_CACHE_KEY, persisted, WIDGET_CACHE_TTL).catch(
+      (error: unknown) => {
+        console.error("[Widgets] Cache repopulation failed:", error);
+      },
+    );
   }
 
   return persisted;
@@ -156,7 +193,7 @@ async function getPersistedWidgetSnapshots(): Promise<WidgetData> {
  * sortStocks(stocks);
  */
 function sortStocks(stocks: StockData[]): StockData[] {
-  return stocks.toSorted((a, b) => {
+  return [...stocks].sort((a, b) => {
     const aIndex = STOCK_SYMBOL_ORDER.indexOf(a.symbol);
     const bIndex = STOCK_SYMBOL_ORDER.indexOf(b.symbol);
     const normalizedA = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex;


### PR DESCRIPTION
## Summary

- Persist weather and market widget snapshots to Supabase cache tables as a durable fallback when Redis is unavailable.
- Refresh widget snapshots during skipped cron runs so manual refreshes can repair an already-published edition.
- Switch market data from the Yahoo quote endpoint to the Yahoo chart endpoint and keep partial snapshots when one symbol fails.
- Document the current widget sources and release this as `0.1.1`.

## Verification

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec playwright test e2e/stock-source.spec.ts --project=chromium`
- `pnpm exec playwright test e2e/stock-source.spec.ts e2e/widget-snapshots.spec.ts --project=chromium`
- `pnpm run test:e2e` (129 passed)

## Release Notes

- This repo does not have a `VERSION` file, so the release marker uses the existing npm package version in `package.json`.
- Added `CHANGELOG.md` for the `0.1.1` release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widget snapshots are now persisted to Supabase as a durable fallback when Redis isn’t available.
  * Weather/stock widget data is refreshed and saved even when cron skips an edition that was already published.
  * Stock collection preserves partial results when one or more symbols fail to load.
* **Documentation**
  * Updated widget docs: weather uses Open-Meteo (no API key) and caching now includes durable Supabase persistence.
  * Removed the old OpenWeatherMap API key from documented environment variables.
* **Tests**
  * Added end-to-end tests covering the stock data source and widget snapshot caching behavior.
* **Chores**
  * Bumped version to **0.1.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->