### PR TITLE
Fix edition tab data switching

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -69,6 +69,11 @@ reviews:
         Check that cron endpoints remain idempotent, protected by CRON_SECRET
         when configured, and consistent with UTC Vercel schedules and JST
         MorningStack edition dates.
+    - path: "src/lib/cron/**"
+      instructions: |
+        Check shared cron library code for idempotency, CRON_SECRET protection
+        when configured, reusable failed-draft cleanup, and consistency between
+        UTC Vercel schedules and JST MorningStack edition dates.
     - path: "src/lib/sources/**"
       instructions: |
         Check external source collectors for rate-limit safety, timeout/failure

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  review_details: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 10
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "[skip review]"
+      - "[skip-review]"
+  tools:
+    eslint:
+      enabled: true
+  finishing_touches:
+    docstrings:
+      enabled: false
+    custom:
+      - name: "tighten TypeScript changes"
+        instructions: |
+          In changed TypeScript files, flag newly introduced `any`, unsafe casts,
+          missing exported return types, and duplicated local types when an
+          existing project type can be reused.
+      - name: "protect public-feed resilience"
+        instructions: |
+          Check changed public feed, auth, and personalization code so Auth.js,
+          bookmark, hidden-item, cache, or optional provider failures cannot hide
+          public MorningStack edition content.
+  path_filters:
+    - "!node_modules/**"
+    - "!.next/**"
+    - "!coverage/**"
+    - "!playwright-report/**"
+    - "!test-results/**"
+    - "!pnpm-lock.yaml"
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.jpeg"
+    - "!**/*.gif"
+    - "!**/*.webp"
+    - "!**/*.ico"
+    - "!**/*.svg"
+  path_instructions:
+    - path: "src/**/*.ts"
+      instructions: |
+        Review as a strict TypeScript, Next.js App Router, Drizzle, and Auth.js
+        codebase. Prefer existing project helpers and types over new abstractions.
+        Pay special attention to server/client boundaries, database query
+        correctness, timezone handling, graceful degradation for optional APIs,
+        and avoiding secrets in logs or client code.
+    - path: "src/**/*.tsx"
+      instructions: |
+        Review React 19 and Next.js App Router components for hydration safety,
+        accessible controls, stable responsive layouts, and state/data alignment.
+        Flag UI state that changes labels without refetching or updating the
+        underlying server-rendered data.
+    - path: "src/app/api/cron/**"
+      instructions: |
+        Check that cron endpoints remain idempotent, protected by CRON_SECRET
+        when configured, and consistent with UTC Vercel schedules and JST
+        MorningStack edition dates.
+    - path: "src/lib/sources/**"
+      instructions: |
+        Check external source collectors for rate-limit safety, timeout/failure
+        handling, stable normalization, and empty-result fallbacks so one source
+        cannot break an edition publish.
+    - path: "e2e/**/*.ts"
+      instructions: |
+        Review Playwright tests for observable user behavior, AAA comments, and
+        coverage across desktop/mobile/tablet when the tested UI is responsive.
+        Prefer deterministic assertions over implementation details.
+    - path: "README.md"
+      instructions: |
+        Verify project documentation stays aligned with vercel.json schedules,
+        environment variables, auth providers, data sources, and public routes.
+    - path: "vercel.json"
+      instructions: |
+        Verify cron entries are written in UTC while documentation and product
+        behavior describe MorningStack editions in Asia/Tokyo time.
+
+chat:
+  auto_reply: true

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,5 +1,24 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { waitForPageReady, isMobileViewport, openMobileMenu } from "./fixtures";
+
+/**
+ * Click an edition tab in the visible desktop header or mobile menu.
+ * @param page - The Playwright page under test.
+ * @param label - The accessible tab label to select.
+ * @returns A resolved promise after the tab click action completes.
+ * @example
+ * await clickEditionTab(page, /Evening/i);
+ */
+async function clickEditionTab(page: Page, label: RegExp): Promise<void> {
+  if (isMobileViewport(page)) {
+    await openMobileMenu(page);
+    const mobileNav = page.getByLabel("Mobile navigation");
+    await mobileNav.getByRole("tab", { name: label }).click();
+    return;
+  }
+
+  await page.locator("header").getByRole("tab", { name: label }).click();
+}
 
 test.describe("Home Page", () => {
   test.beforeEach(async ({ page }) => {
@@ -19,11 +38,15 @@ test.describe("Home Page", () => {
       // On mobile, tabs are inside hamburger menu
       await openMobileMenu(page);
       const mobileNav = page.getByLabel("Mobile navigation");
-      const tablist = mobileNav.getByRole("tablist", { name: "Edition selector" });
+      const tablist = mobileNav.getByRole("tablist", {
+        name: "Edition selector",
+      });
       await expect(tablist).toBeVisible();
     } else {
       // On desktop, tabs are in the header
-      const tablist = page.getByRole("tablist", { name: "Edition selector" }).first();
+      const tablist = page
+        .getByRole("tablist", { name: "Edition selector" })
+        .first();
       await expect(tablist).toBeVisible();
 
       const morningTab = page.getByRole("tab", { name: /Morning/i }).first();
@@ -36,8 +59,15 @@ test.describe("Home Page", () => {
   test("displays either edition content or no-edition fallback", async ({
     page,
   }) => {
-    const hasContent = await page.getByText("No edition available").isVisible().catch(() => false);
-    const hasSections = await page.locator("h2").first().isVisible().catch(() => false);
+    const hasContent = await page
+      .getByText("No edition available")
+      .isVisible()
+      .catch(() => false);
+    const hasSections = await page
+      .locator("h2")
+      .first()
+      .isVisible()
+      .catch(() => false);
 
     // One of them must be true — the page successfully rendered
     expect(hasContent || hasSections).toBeTruthy();
@@ -72,12 +102,16 @@ test.describe("Edition Tab Switching", () => {
     if (isMobileViewport(page)) {
       await openMobileMenu(page);
       const mobileNav = page.getByLabel("Mobile navigation");
-      const selectedTab = mobileNav.locator('[role="tab"][aria-selected="true"]');
+      const selectedTab = mobileNav.locator(
+        '[role="tab"][aria-selected="true"]',
+      );
       await expect(selectedTab).toBeVisible();
       const tabText = await selectedTab.textContent();
       expect(tabText).toMatch(/Morning|Evening/);
     } else {
-      const selectedTab = page.locator('[role="tab"][aria-selected="true"]').first();
+      const selectedTab = page
+        .locator('[role="tab"][aria-selected="true"]')
+        .first();
       await expect(selectedTab).toBeVisible();
       const tabText = await selectedTab.textContent();
       expect(tabText).toMatch(/Morning|Evening/);
@@ -132,6 +166,25 @@ test.describe("Edition Tab Switching", () => {
     await expect(eveningTabAfter).toHaveAttribute("aria-selected", "false");
   });
 
+  test("clicking edition tabs navigates to edition-specific URL so server data can refresh", async ({
+    page,
+  }) => {
+    // Arrange
+    await expect(page.locator("header")).toBeVisible();
+
+    // Act
+    await clickEditionTab(page, /Evening/i);
+
+    // Assert
+    await expect(page).toHaveURL(/[?&]edition=evening(?:&|$)/);
+
+    // Act
+    await clickEditionTab(page, /Morning/i);
+
+    // Assert
+    await expect(page).toHaveURL(/[?&]edition=morning(?:&|$)/);
+  });
+
   test("edition date updates in header subtitle", async ({ page }) => {
     /**
      * Scope queries to the visible navigation section.
@@ -150,7 +203,10 @@ test.describe("Edition Tab Switching", () => {
     await expect(scope.getByText(/Edition/i).first()).toBeVisible();
 
     // Click evening tab
-    await scope.getByRole("tab", { name: /Evening/i }).first().click();
+    await scope
+      .getByRole("tab", { name: /Evening/i })
+      .first()
+      .click();
 
     // On mobile, tab click closes the menu — need to wait then reopen
     if (isMobileViewport(page)) {
@@ -161,7 +217,10 @@ test.describe("Edition Tab Switching", () => {
     await expect(scope.getByText("Evening Edition").first()).toBeVisible();
 
     // Click morning tab
-    await scope.getByRole("tab", { name: /Morning/i }).first().click();
+    await scope
+      .getByRole("tab", { name: /Morning/i })
+      .first()
+      .click();
 
     if (isMobileViewport(page)) {
       await page.waitForTimeout(300);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,11 @@ export const metadata: Metadata = {
 type HiddenState = NonNullable<HomeContentProps["hiddenState"]>;
 type HomeSearchParams = Promise<{ edition?: string | string[] }>;
 
+interface ResolvedEditionSelection {
+  editionType: EditionType;
+  isExplicitSelection: boolean;
+}
+
 const EMPTY_HIDDEN_STATE: HiddenState = {
   hiddenArticleIds: [],
   hiddenSources: [],
@@ -52,23 +57,23 @@ const EMPTY_HIDDEN_STATE: HiddenState = {
  * Pick the first edition query value so tab navigation can request server data.
  * @param value - The raw `edition` search parameter from Next.js.
  * @param fallbackEditionType - The time-based edition used when the URL is absent or invalid.
- * @returns The requested edition when valid, otherwise the fallback edition.
+ * @returns The selected edition plus whether the URL explicitly requested it.
  * @example
- * resolveEditionSearchParam("morning", "evening") // => "morning"
- * resolveEditionSearchParam("weekly", "evening") // => "evening"
+ * resolveEditionSearchParam("morning", "evening") // => { editionType: "morning", isExplicitSelection: true }
+ * resolveEditionSearchParam("weekly", "evening") // => { editionType: "evening", isExplicitSelection: false }
  */
 function resolveEditionSearchParam(
   value: string | string[] | undefined,
   fallbackEditionType: EditionType,
-): EditionType {
+): ResolvedEditionSelection {
   const requestedEditionType = Array.isArray(value) ? value[0] : value;
   if (
     requestedEditionType === "morning" ||
     requestedEditionType === "evening"
   ) {
-    return requestedEditionType;
+    return { editionType: requestedEditionType, isExplicitSelection: true };
   }
-  return fallbackEditionType;
+  return { editionType: fallbackEditionType, isExplicitSelection: false };
 }
 
 /**
@@ -84,6 +89,7 @@ function getDefaultEditionType(): EditionType {
       timeZone: "Asia/Tokyo",
       hour: "numeric",
       hour12: false,
+      hourCycle: "h23",
     }).format(now),
   );
   return tokyoHour < 12 ? "morning" : "evening";
@@ -134,7 +140,7 @@ export default async function HomePage({
   searchParams: HomeSearchParams;
 }) {
   const resolvedSearchParams = await searchParams;
-  const editionType = resolveEditionSearchParam(
+  const editionSelection = resolveEditionSearchParam(
     resolvedSearchParams.edition,
     getDefaultEditionType(),
   );
@@ -142,7 +148,10 @@ export default async function HomePage({
   return (
     <main className="relative mx-auto max-w-[1440px] px-4 py-4 sm:px-6 lg:px-8">
       <Suspense fallback={<HomePageSkeleton />}>
-        <EditionContent editionType={editionType} />
+        <EditionContent
+          editionType={editionSelection.editionType}
+          allowLatestFallback={!editionSelection.isExplicitSelection}
+        />
       </Suspense>
     </main>
   );
@@ -151,20 +160,29 @@ export default async function HomePage({
 /**
  * Fetch all edition data while keeping public news independent from personalization.
  * @param editionType - The edition selected by URL or by JST default time.
+ * @param allowLatestFallback - Whether missing same-day content may fall back to the latest published edition.
  * @returns Edition data when DB content exists, otherwise `null` for the no-edition state.
  * @example
- * const data = await fetchEditionData("morning");
+ * const data = await fetchEditionData("morning", false);
  */
-async function fetchEditionData(editionType: EditionType) {
+async function fetchEditionData(
+  editionType: EditionType,
+  allowLatestFallback: boolean,
+) {
   try {
     const today = getTodayJST();
 
-    const [edition, widgets, bookmarkedIds, hiddenState] = await Promise.all([
-      getEdition(editionType, today).then((e) => e ?? getLatestEdition()),
-      getWidgetData(),
-      getSafeBookmarkedIds(),
-      getSafeHiddenState(),
-    ]);
+    const [requestedEdition, widgets, bookmarkedIds, hiddenState] =
+      await Promise.all([
+        getEdition(editionType, today),
+        getWidgetData(),
+        getSafeBookmarkedIds(),
+        getSafeHiddenState(),
+      ]);
+
+    const edition =
+      requestedEdition ??
+      (allowLatestFallback ? await getLatestEdition() : null);
 
     if (!edition) return null;
 
@@ -212,13 +230,19 @@ async function getSafeHiddenState(): Promise<HiddenState> {
 
 /**
  * Fetch and render the selected edition inside the page Suspense boundary.
- * @param props - The edition selected by URL or by default JST timing.
+ * @param props - The edition selection and fallback behavior for this render.
  * @returns The populated home content or the no-edition fallback.
  * @example
- * <EditionContent editionType="evening" />
+ * <EditionContent editionType="evening" allowLatestFallback={false} />
  */
-async function EditionContent({ editionType }: { editionType: EditionType }) {
-  const data = await fetchEditionData(editionType);
+async function EditionContent({
+  editionType,
+  allowLatestFallback,
+}: {
+  editionType: EditionType;
+  allowLatestFallback: boolean;
+}) {
+  const data = await fetchEditionData(editionType, allowLatestFallback);
 
   if (!data) {
     return <NoEditionFallback />;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { getHiddenState } from "@/app/actions/hidden";
 import { HomeContent } from "@/components/home-content";
 import type { HomeContentProps } from "@/components/home-content";
 import { Skeleton } from "@/components/ui/skeleton";
+import type { EditionType } from "@/lib/features/edition-slice";
 
 // ─── Route Segment Config ───────────────────────────────────────────
 
@@ -39,6 +40,7 @@ export const metadata: Metadata = {
 // ─── Helpers ────────────────────────────────────────────────────────
 
 type HiddenState = NonNullable<HomeContentProps["hiddenState"]>;
+type HomeSearchParams = Promise<{ edition?: string | string[] }>;
 
 const EMPTY_HIDDEN_STATE: HiddenState = {
   hiddenArticleIds: [],
@@ -47,12 +49,35 @@ const EMPTY_HIDDEN_STATE: HiddenState = {
 };
 
 /**
- * Determine the default edition type based on the current hour in Asia/Tokyo.
- *
- * Before 12:00 JST → morning, 12:00+ JST → evening.
- * Matches the logic in the cron collector.
+ * Pick the first edition query value so tab navigation can request server data.
+ * @param value - The raw `edition` search parameter from Next.js.
+ * @param fallbackEditionType - The time-based edition used when the URL is absent or invalid.
+ * @returns The requested edition when valid, otherwise the fallback edition.
+ * @example
+ * resolveEditionSearchParam("morning", "evening") // => "morning"
+ * resolveEditionSearchParam("weekly", "evening") // => "evening"
  */
-function getDefaultEditionType(): "morning" | "evening" {
+function resolveEditionSearchParam(
+  value: string | string[] | undefined,
+  fallbackEditionType: EditionType,
+): EditionType {
+  const requestedEditionType = Array.isArray(value) ? value[0] : value;
+  if (
+    requestedEditionType === "morning" ||
+    requestedEditionType === "evening"
+  ) {
+    return requestedEditionType;
+  }
+  return fallbackEditionType;
+}
+
+/**
+ * Determine the default edition type when the home page loads without a tab query.
+ * @returns `morning` before 12:00 JST, otherwise `evening`.
+ * @example
+ * const defaultEditionType = getDefaultEditionType();
+ */
+function getDefaultEditionType(): EditionType {
   const now = new Date();
   const tokyoHour = Number(
     new Intl.DateTimeFormat("en-US", {
@@ -65,7 +90,10 @@ function getDefaultEditionType(): "morning" | "evening" {
 }
 
 /**
- * Get today's date as YYYY-MM-DD in Asia/Tokyo timezone.
+ * Get today's JST date for edition lookup triggered by the home page render.
+ * @returns Date text formatted as `YYYY-MM-DD`.
+ * @example
+ * const today = getTodayJST();
  */
 function getTodayJST(): string {
   return new Intl.DateTimeFormat("en-CA", {
@@ -77,8 +105,11 @@ function getTodayJST(): string {
 }
 
 /**
- * Convert a Map to a plain Record for serialization across the
- * React Server Component → Client Component boundary.
+ * Convert a Map to a plain object so Server Components can pass grouped articles.
+ * @param map - The source map keyed by string IDs.
+ * @returns A serializable record containing the same entries.
+ * @example
+ * mapToRecord(new Map([["hackernews", []]])) // => { hackernews: [] }
  */
 function mapToRecord<K extends string, V>(map: Map<K, V>): Record<string, V> {
   const record: Record<string, V> = {};
@@ -91,41 +122,41 @@ function mapToRecord<K extends string, V>(map: Map<K, V>): Record<string, V> {
 // ─── Page Component ─────────────────────────────────────────────────
 
 /**
- * MorningStack home page — async Server Component.
- *
- * Fetches the current edition from the database based on time-of-day
- * (morning/evening) and today's date in JST. Falls back to the latest
- * published edition if none exists for today, or shows an empty state
- * message if no editions have been published at all.
- *
- * Widget data (weather, stocks) is fetched from Redis cache populated
- * by the cron collector.
+ * Render the public briefing and honor the edition query when a tab navigates.
+ * @param props - Next.js route props containing async search params.
+ * @returns The home page shell with Suspense-wrapped edition data.
+ * @example
+ * <HomePage searchParams={Promise.resolve({ edition: "morning" })} />
  */
-export default async function HomePage() {
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: HomeSearchParams;
+}) {
+  const resolvedSearchParams = await searchParams;
+  const editionType = resolveEditionSearchParam(
+    resolvedSearchParams.edition,
+    getDefaultEditionType(),
+  );
+
   return (
     <main className="relative mx-auto max-w-[1440px] px-4 py-4 sm:px-6 lg:px-8">
       <Suspense fallback={<HomePageSkeleton />}>
-        <EditionContent />
+        <EditionContent editionType={editionType} />
       </Suspense>
     </main>
   );
 }
 
 /**
- * Async data-fetching component wrapped in Suspense.
- *
- * Separated from the page export so that the Suspense boundary can
- * show a skeleton while the DB and Redis queries resolve.
- */
-/**
  * Fetch all edition data while keeping public news independent from personalization.
+ * @param editionType - The edition selected by URL or by JST default time.
  * @returns Edition data when DB content exists, otherwise `null` for the no-edition state.
  * @example
- * const data = await fetchEditionData();
+ * const data = await fetchEditionData("morning");
  */
-async function fetchEditionData() {
+async function fetchEditionData(editionType: EditionType) {
   try {
-    const editionType = getDefaultEditionType();
     const today = getTodayJST();
 
     const [edition, widgets, bookmarkedIds, hiddenState] = await Promise.all([
@@ -179,8 +210,15 @@ async function getSafeHiddenState(): Promise<HiddenState> {
   }
 }
 
-async function EditionContent() {
-  const data = await fetchEditionData();
+/**
+ * Fetch and render the selected edition inside the page Suspense boundary.
+ * @param props - The edition selected by URL or by default JST timing.
+ * @returns The populated home content or the no-edition fallback.
+ * @example
+ * <EditionContent editionType="evening" />
+ */
+async function EditionContent({ editionType }: { editionType: EditionType }) {
+  const data = await fetchEditionData(editionType);
 
   if (!data) {
     return <NoEditionFallback />;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useSession, signOut } from "next-auth/react";
 import { useTheme } from "next-themes";
 import { LogIn } from "lucide-react";
@@ -34,10 +35,22 @@ function formatEditionDate(dateStr: string, editionType: EditionType): string {
 }
 
 /**
+ * Build the home URL that makes App Router refetch the selected edition.
+ * @param editionType - The edition chosen from desktop or mobile tabs.
+ * @returns A root URL with the edition search parameter.
+ * @example
+ * getEditionHref("morning") // => "/?edition=morning"
+ */
+function getEditionHref(editionType: EditionType): `/?edition=${EditionType}` {
+  return `/?edition=${editionType}`;
+}
+
+/**
  * App header with edition tabs, auth controls, and mobile hamburger menu.
  * Client Component — uses Redux for edition state and next-auth/react for session.
  */
 export function Header() {
+  const router = useRouter();
   const { data: session } = useSession();
   const { resolvedTheme, setTheme: setNextTheme } = useTheme();
   const mounted = useSyncExternalStore(
@@ -54,6 +67,15 @@ export function Header() {
     { type: "morning", label: "Morning", icon: "☀️" },
     { type: "evening", label: "Evening", icon: "🌙" },
   ];
+
+  const handleEditionSelect = useCallback(
+    (selectedEditionType: EditionType) => {
+      // Keep the tab responsive while the URL navigation fetches matching data.
+      dispatch(setEditionType(selectedEditionType));
+      router.push(getEditionHref(selectedEditionType));
+    },
+    [dispatch, router],
+  );
 
   return (
     <header className="glass-elevated sticky top-0 z-50">
@@ -83,7 +105,7 @@ export function Header() {
                     ? "text-ms-accent"
                     : "text-ms-text-muted hover:text-ms-text-secondary"
                 }`}
-                onClick={() => dispatch(setEditionType(tab.type))}
+                onClick={() => handleEditionSelect(tab.type)}
               >
                 <span aria-hidden="true">{tab.icon}</span> {tab.label}
                 {/* Active tab underline */}
@@ -215,7 +237,7 @@ export function Header() {
                     : "text-ms-text-muted hover:text-ms-text-secondary"
                 }`}
                 onClick={() => {
-                  dispatch(setEditionType(tab.type));
+                  handleEditionSelect(tab.type);
                   dispatch(setSidebarOpen(false));
                 }}
               >


### PR DESCRIPTION
## Summary
- Load the home page edition from the `?edition=morning|evening` query so App Router refetches the matching server data.
- Navigate header edition tabs to edition-specific URLs while keeping the tab state responsive.
- Add a repository-level `.coderabbit.yaml` tuned for MorningStack's Next.js, TypeScript, cron, source collector, and Playwright review patterns.

## Test plan
- `pnpm exec prettier --check .coderabbit.yaml`
- `git diff --check`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `npx --yes kill-port 3198`
- `pnpm exec playwright test e2e/home.spec.ts`

## Notes
- CodeRabbit config format and options were checked against current Context7 CodeRabbit documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edition selection now persists via URL query parameters, making edition pages shareable and bookmarkable.
  * Switching edition tabs now updates the URL and refreshes server-rendered content.
  * The home page continues to default to morning before 12:00 JST, otherwise evening.
* **Bug Fixes**
  * Improved edition-tab behavior consistency across mobile and desktop.
* **Tests**
  * Added Playwright coverage for edition tab navigation and URL `edition` updates across form factors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->